### PR TITLE
fix: long manufacturer and model name not being displayed entirely, feat: webserver opening in Custom Tabs

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -37,6 +37,7 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.3.1'
     implementation 'com.google.android.material:material:1.4.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.0'
+    implementation 'androidx.browser:browser:1.3.0'
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'

--- a/app/src/main/java/cloud/valetudo/companion/MainActivity.kt
+++ b/app/src/main/java/cloud/valetudo/companion/MainActivity.kt
@@ -1,16 +1,18 @@
 package cloud.valetudo.companion
 
 import android.content.Context
-import android.net.nsd.NsdManager
-import android.net.nsd.NsdServiceInfo
-import androidx.appcompat.app.AppCompatActivity
-import android.os.Bundle
-import android.util.Log
-import kotlin.collections.ArrayList
 import android.content.Intent
 import android.net.Uri
+import android.net.nsd.NsdManager
+import android.net.nsd.NsdServiceInfo
+import android.os.Bundle
+import android.util.Log
 import android.view.View
 import android.widget.*
+import androidx.appcompat.app.AppCompatActivity
+import androidx.browser.customtabs.CustomTabColorSchemeParams
+import androidx.browser.customtabs.CustomTabsIntent
+import androidx.core.content.res.ResourcesCompat
 import com.google.android.material.floatingactionbutton.FloatingActionButton
 import java.util.concurrent.Semaphore
 import kotlin.concurrent.thread
@@ -52,9 +54,15 @@ class MainActivity : AppCompatActivity() {
 
         discoveredList.onItemClickListener = AdapterView.OnItemClickListener { _, _, position, _ ->
             val instance = mValetudoInstances[position]
-            val browserIntent = Intent(Intent.ACTION_VIEW, Uri.parse("http://${instance.host}"))
+            var builder = CustomTabsIntent.Builder()
 
-            startActivity(browserIntent)
+            val defaultColors = CustomTabColorSchemeParams.Builder()
+                .setToolbarColor(ResourcesCompat.getColor(resources, R.color.valetudo_main, null))
+                .build()
+            builder.setDefaultColorSchemeParams(defaultColors)
+
+            var customTabsIntent: CustomTabsIntent = builder.build();
+            customTabsIntent.launchUrl(this, Uri.parse("http://${instance.host}"))
         }
 
         provisionButton.setOnClickListener {

--- a/app/src/main/res/layout/discovered_instance_list_item_layout.xml
+++ b/app/src/main/res/layout/discovered_instance_list_item_layout.xml
@@ -7,50 +7,66 @@
 
     <TextView
         android:id="@+id/manufacturerAndModel"
-        android:layout_width="380dp"
+        android:layout_width="0dp"
         android:layout_height="30dp"
         android:layout_marginStart="20dp"
         android:layout_marginTop="5dp"
+        android:layout_marginEnd="20dp"
+        android:ellipsize="end"
         android:gravity="bottom"
+        android:maxLines="1"
         android:textSize="24sp"
+        app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"
         tools:text="manufacturerAndModel" />
 
-    <TextView
-        android:id="@+id/valetudoVersion"
-        android:layout_width="180dp"
+    <TableLayout
+        android:id="@+id/tableLayout"
+        android:layout_width="0dp"
         android:layout_height="25dp"
         android:layout_marginStart="20dp"
-        android:layout_marginTop="5dp"
-        android:gravity="bottom"
-        android:textSize="20sp"
+        android:layout_marginEnd="20dp"
+        app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/manufacturerAndModel"
-        tools:text="valetudoVersion" />
+        app:layout_constraintTop_toBottomOf="@id/manufacturerAndModel"
+        android:stretchColumns="0,1">
 
-    <TextView
-        android:id="@+id/uniqueIdentifier"
-        android:layout_width="195dp"
-        android:layout_height="25dp"
-        android:layout_marginStart="5dp"
-        android:layout_marginTop="5dp"
-        android:gravity="bottom"
-        android:textStyle="italic"
-        app:layout_constraintStart_toEndOf="@+id/valetudoVersion"
-        app:layout_constraintTop_toBottomOf="@+id/manufacturerAndModel"
-        tools:text="uniqueIdentifier" />
+        <TableRow
+            android:layout_width="match_parent"
+            android:layout_height="match_parent">
+
+            <TextView
+                android:id="@+id/valetudoVersion"
+                android:layout_height="match_parent"
+                android:gravity="bottom"
+                android:textSize="20sp"
+                android:layout_column="0"
+                tools:text="valetudoVersion" />
+
+            <TextView
+                android:id="@+id/uniqueIdentifier"
+                android:layout_height="match_parent"
+                android:layout_column="1"
+                android:gravity="center_vertical"
+                android:textStyle="italic"
+                tools:text="uniqueIdentifier" />
+        </TableRow>
+
+    </TableLayout>
 
     <TextView
         android:id="@+id/domainAndHost"
-        android:layout_width="380dp"
+        android:layout_width="0dp"
         android:layout_height="15dp"
         android:layout_marginStart="20dp"
         android:layout_marginTop="5dp"
+        android:layout_marginEnd="20dp"
         android:gravity="bottom"
         android:textSize="12sp"
+        app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/valetudoVersion"
+        app:layout_constraintTop_toBottomOf="@id/tableLayout"
         tools:text="domainAndHost" />
 
     <Space


### PR DESCRIPTION
## Type of change

Type A:
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] UI Feature
- [ ] Refactor/Code Cleanup

# Description (Type A)

Fixed manufacturer and model TextView not being displayed entirely if too long, made discovered_instance_list_item_layout responsive
Original                         |  &nbsp;&nbsp;&nbsp;New&nbsp;&nbsp;&nbsp;
:-------------------------:|:-------------------------:
![Screenshot_2021-10-02-20-19-08-151_cloud valetudo companion](https://user-images.githubusercontent.com/6378002/135749286-fc6bdbd7-5f9f-4d51-91fe-9576495f1fde.jpg) | ![Screenshot_2021-10-02-20-18-16-122_cloud valetudo companion](https://user-images.githubusercontent.com/6378002/135749285-fa7d27d3-1da2-45ae-835d-b1da6f28068a.jpg)

Added webserver opening in Custom Tabs (if supported, see https://developer.chrome.com/docs/android/custom-tabs/)