### PR TITLE
Fix requesting permissions

### DIFF
--- a/app/src/main/java/cloud/valetudo/companion/ProvisioningWizardPageOneActivity.kt
+++ b/app/src/main/java/cloud/valetudo/companion/ProvisioningWizardPageOneActivity.kt
@@ -57,21 +57,10 @@ class ProvisioningWizardPageOneActivity: AppCompatActivity()  {
 
                 startActivity(wizardPageTwoIntent)
             } else {
-                if (ActivityCompat.shouldShowRequestPermissionRationale(this, Manifest.permission.ACCESS_FINE_LOCATION)) {
-                    ActivityCompat.requestPermissions(this,
-                        PERMISSIONS_REQUIRED,
-                        PERMISSION_REQUEST_CODE
-                    )
-                } else {
-                    runOnUiThread {
-                        Toast.makeText(
-                            this@ProvisioningWizardPageOneActivity,
-                            "Wi-Fi SSID scanning requires the ACCESS_FINE_LOCATION permission.\nDid you select \"Don't ask again\"?",
-                            Toast.LENGTH_LONG
-                        ).show()
-                    }
-                }
-
+                ActivityCompat.requestPermissions(this,
+                    PERMISSIONS_REQUIRED,
+                    PERMISSION_REQUEST_CODE
+                )
             }
         }
 


### PR DESCRIPTION
ActivityCompat.shouldShowRequestPermissionRationale only returns true when Android decides that the user needs extra explanation to understand why they need to grant the permission. It shouldn't be used as a check for "should we ask for the permission".